### PR TITLE
step8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./go/dockerfile
+    ports:
+      - 9000:9000
+    environment:
+      - FRONT_URL=http://localhost:3000
+  web:
+    build:
+      context: .
+      dockerfile: ./typescript/simple-mercari-web/dockerfile
+    ports:
+      - 3000:3000
+    environment:
+      - REACT_APP_API_URL=http://localhost:9000
+    depends_on:
+      - app

--- a/typescript/simple-mercari-web/dockerfile
+++ b/typescript/simple-mercari-web/dockerfile
@@ -2,6 +2,9 @@ FROM node:20-alpine
 WORKDIR /app
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
-USER trainee
 
-CMD ["node", "-v"]
+COPY . /app
+
+RUN npm ci
+
+CMD npm start


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
### **1. フロントエンドの docker image を作成する**
`typescript/simple-mercari-web`以下のDockerfileを変更し、フロントエンドがdocker上で立ち上がるようにした。
```
% docker build -t build2024/web:latest .
[+] Building 93.2s (10/10) FINISHED                                                                                                                docker:desktop-linux
 => [internal] load build definition from dockerfile                                                                                                               0.0s
 => => transferring dockerfile: 207B                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/node:20-alpine                                                                                                  0.9s
 => [internal] load .dockerignore                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                    0.0s
 => [1/5] FROM docker.io/library/node:20-alpine@sha256:c0a3badbd8a0a760de903e00cedbca94588e609299820557e72cba2a53dbaa2c                                            0.0s
 => [internal] load build context                                                                                                                                  4.7s
 => => transferring context: 2.85MB                                                                                                                                4.5s
 => CACHED [2/5] WORKDIR /app                                                                                                                                      0.0s
 => CACHED [3/5] RUN addgroup -S mercari && adduser -S trainee -G mercari                                                                                          0.0s
 => [4/5] COPY . /app                                                                                                                                             10.5s
 => [5/5] RUN npm ci                                                                                                                                              69.4s
 => exporting to image                                                                                                                                             7.1s 
 => => exporting layers                                                                                                                                            7.1s 
 => => writing image sha256:ac3843ec92ab095923f6335ef5d2b2253effa0a45dca31662a0fdddeef06b614                                                                       0.0s 
 => => naming to docker.io/build2024/web:latest                                                                                                                    0.0s 
                                                                                                                                                                        
View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/1orewo5e0uqmkixq661598f4o                                                              

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```
```
% docker images                          
REPOSITORY                                  TAG       IMAGE ID       CREATED          SIZE
build2024/web                               latest    ac3843ec92ab   26 seconds ago   693MB
```
`$ docker run -d -p 3000:3000 build2024/web:latest`を実行するとhttp://localhost:3000/ にアクセスできるようになった。

### **2. Docker Compose をインストールする**
Docker Composeをインストールし、docker-compose -v が実行できることを確認した。
```
% docker-compose -v 
Docker Compose version v2.24.5-desktop.1
```

### **3. Docker Compose のチュートリアルをやってみる**
[Docker Compose のチュートリアル](https://matsuand.github.io/docs.docker.jp.onthefly/compose/gettingstarted/)に取り組みました。

### **4. Docker ComposeでAPIとフロントエンドを動かす**
(Option 2: 難易度 ☆☆☆) {go|python}/Dockerfile と typescript/simple-mercari-web/Dockerfile から build するようにする
に取り組んだ。
docker-compose.ymlの2つのサービスでimageをbuildし、それぞれ適切なポートに接続した。環境変数としてREACT_APP_API_URLとFRONT_URLを設定した。
`docker-compose up`でサービスを起動させ、正しく動作させることができた。

```
 % docker-compose up  
[+] Running 3/3
 ✔ Network mercari-build-training_default  Created                                                                                                0.1s 
 ✔ Container mercari-build-training-app-1  Created                                                                                                0.6s 
 ✔ Container mercari-build-training-web-1  Created                                                                                                0.1s 
Attaching to app-1, web-1
web-1  | 
web-1  | > simple-mercari-web@0.1.0 start
web-1  | > react-scripts start
web-1  | 
app-1  | 
app-1  |    ____    __
app-1  |   / __/___/ /  ___
app-1  |  / _// __/ _ \/ _ \
app-1  | /___/\__/_//_/\___/ v4.11.4
app-1  | High performance, minimalist Go web framework
app-1  | https://echo.labstack.com
app-1  | ____________________________________O/_______
app-1  |                                     O\
app-1  | ⇨ http server started on [::]:9000
web-1  | Browserslist: caniuse-lite is outdated. Please run:
web-1  |   npx browserslist@latest --update-db
web-1  |   Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
web-1  | (node:25) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
web-1  | (Use `node --trace-deprecation ...` to show where the warning was created)
web-1  | (node:25) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
web-1  | Starting the development server...
web-1  | 
web-1  | Compiled with warnings.
web-1  | 
web-1  | src/components/ItemList/ItemList.tsx
web-1  |   Line 11:7:  'placeholderImage' is assigned a value but never used                                                          @typescript-eslint/no-unused-vars
web-1  |   Line 46:6:  React Hook useEffect has a missing dependency: 'fetchItems'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
web-1  | 
web-1  | Search for the keywords to learn more about each warning.
web-1  | To ignore, add // eslint-disable-next-line to the line before.
web-1  | 
web-1  | assets by path static/js/*.js 1.5 MiB
web-1  |   asset static/js/bundle.js 1.49 MiB [emitted] (name: main) 1 related asset
web-1  |   asset static/js/node_modules_web-vitals_dist_web-vitals_js.chunk.js 6.94 KiB [emitted] 1 related asset
web-1  | asset index.html 1.69 KiB [emitted]
web-1  | asset asset-manifest.json 458 bytes [emitted]
web-1  | runtime modules 31.4 KiB 15 modules
web-1  | modules by path ./node_modules/ 1.35 MiB 99 modules
web-1  | modules by path ./src/ 26.3 KiB
web-1  |   modules by path ./src/*.css 11 KiB
web-1  |     ./src/index.css 2.72 KiB [built] [code generated]
web-1  |     ./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[1].oneOf[5].use[2]!./node_modules/source-map-loader/dist/cjs.js!./src/index.css 1.37 KiB [built] [code generated]
web-1  |     + 2 modules
web-1  |   modules by path ./src/components/ 9.35 KiB
web-1  |     modules by path ./src/components/ItemList/*.tsx 4.47 KiB 2 modules
web-1  |     modules by path ./src/components/Listing/*.tsx 4.88 KiB 2 modules
web-1  |   modules by path ./src/*.tsx 4.58 KiB
web-1  |     ./src/index.tsx 1.73 KiB [built] [code generated]
web-1  |     ./src/App.tsx 2.85 KiB [built] [code generated]
web-1  |   ./src/reportWebVitals.ts 1.36 KiB [built] [code generated]
web-1  | 
web-1  | WARNING in src/components/ItemList/ItemList.tsx
web-1  |   Line 11:7:  'placeholderImage' is assigned a value but never used                                                          @typescript-eslint/no-unused-vars
web-1  |   Line 46:6:  React Hook useEffect has a missing dependency: 'fetchItems'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
web-1  | 
web-1  | webpack 5.70.0 compiled with 1 warning in 27263 ms
web-1  | No issues found.
web-1  | Compiling...
web-1  | Compiled with warnings.
web-1  | 
web-1  | src/components/ItemList/ItemList.tsx
web-1  |   Line 11:7:  'placeholderImage' is assigned a value but never used                                                          @typescript-eslint/no-unused-vars
web-1  |   Line 46:6:  React Hook useEffect has a missing dependency: 'fetchItems'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
web-1  | 
web-1  | Search for the keywords to learn more about each warning.
web-1  | To ignore, add // eslint-disable-next-line to the line before.
web-1  | 
web-1  | assets by status 6.94 KiB [cached] 1 asset
web-1  | assets by chunk 1.49 MiB (name: main)
web-1  |   asset static/js/bundle.js 1.49 MiB [emitted] (name: main) 1 related asset
web-1  |   asset main.3dde7a04caa8ec682a3b.hot-update.js 369 bytes [emitted] [immutable] [hmr] (name: main) 1 related asset
web-1  | assets by path *.json 611 bytes
web-1  |   asset asset-manifest.json 583 bytes [emitted]
web-1  |   asset main.3dde7a04caa8ec682a3b.hot-update.json 28 bytes [emitted] [immutable] [hmr]
web-1  | asset index.html 1.69 KiB [emitted]
web-1  | Entrypoint main 1.49 MiB (1.5 MiB) = static/js/bundle.js 1.49 MiB main.3dde7a04caa8ec682a3b.hot-update.js 369 bytes 2 auxiliary assets
web-1  | cached modules 1.37 MiB [cached] 110 modules
web-1  | runtime modules 31.4 KiB 15 modules
web-1  | 
web-1  | WARNING in src/components/ItemList/ItemList.tsx
web-1  |   Line 11:7:  'placeholderImage' is assigned a value but never used                                                          @typescript-eslint/no-unused-vars
web-1  |   Line 46:6:  React Hook useEffect has a missing dependency: 'fetchItems'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
web-1  | 
web-1  | webpack 5.70.0 compiled with 1 warning in 1518 ms
web-1  | No issues found.
```

<img width="678" alt="スクリーンショット 2024-02-29 15 12 55" src="https://github.com/hinako1217/mercari-build-training/assets/133786698/01b0ad56-ae8a-4526-8af2-026537b67312">


## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
